### PR TITLE
⚙️ Chore: cn함수도입 tailwindcss설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^8.19.0",
         "@typescript-eslint/parser": "^8.19.0",
+        "clsx": "^2.1.1",
         "globals": "^15.14.0",
         "next": "15.1.3",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "tailwind-merge": "^3.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1587,6 +1589,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -5078,6 +5089,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.0.1.tgz",
+      "integrity": "sha512-AvzE8FmSoXC7nC+oU5GlQJbip2UO7tmOhOfQyOmPhrStOGXHU08j8mZEHZ4BmCqY5dWTCo4ClWkNyRNx1wpT0g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "@typescript-eslint/parser": "^8.19.0",
+    "clsx": "^2.1.1",
     "globals": "^15.14.0",
     "next": "15.1.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/components/global/input/IconInput.tsx
+++ b/src/components/global/input/IconInput.tsx
@@ -4,6 +4,7 @@ import { IconInputProps } from './input.types'
 import { getStatusStyles, inputSizes } from './inputStyles'
 import Search from '@/assets/svg/search.svg'
 import SearchDisabled from '@/assets/svg/search-disabled.svg'
+import cn from '@/utils/cn'
 
 export default function IconInput({
   name,
@@ -22,11 +23,12 @@ export default function IconInput({
 
   return (
     <div
-      className={`w-full flex items-center gap-2 rounded-lg border-[1.5px] px-4 py-3
-        ${isFocused ? 'border-accentT-30' : ''}
-        ${getStatusStyles(status)}
-        ${inputSizes[size]}
-      `}
+      className={cn(
+        'w-full flex items-center gap-2 rounded-lg border-[1.5px] px-4 py-3',
+        isFocused && 'border-accentT-30',
+        getStatusStyles(status),
+        inputSizes[size]
+      )}
     >
       <span>
         {iconArrow === 'left' && <Image src={!disabled ? Search : SearchDisabled} alt="icon" width={24} height={24} />}

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export default function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,17 @@
 import type { Config } from 'tailwindcss'
 
+const px0To10 = {
+  ...Array.from(Array(11)).reduce((acc, _, i) => ({ ...acc, [i]: `${i}px` }), {}),
+}
+
+const px0To100 = {
+  ...Array.from(Array(101)).reduce((acc, _, i) => ({ ...acc, [i]: `${i}px` }), {}),
+}
+
+const px0To1000 = {
+  ...Array.from(Array(1001)).reduce((acc, _, i) => ({ ...acc, [i]: `${i}px` }), {}),
+}
+
 export default {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
@@ -77,6 +89,15 @@ export default {
           5: 'rgba(3, 236, 214, 0.05)',
         },
       },
+      width: px0To1000,
+      height: px0To1000,
+      borderWidth: px0To10,
+      fontSize: px0To100,
+      lineHeight: px0To100,
+      minWidth: px0To1000,
+      minHeight: px0To1000,
+      spacing: px0To1000,
+      borderRadius: { ...px0To100, button: '6px' },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 🔗 연관된 이슈

#19 


## 🎲 PR 유형

- [ ] 새로운 기능 추가
- [ ] 기능 삭제
- [ ] 디자인 추가 및 수정
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기능에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경, 주석 추가 및 수정)


--- 

## 🪄 작업 내용

**1. cn 함수 도입**
- 조건부 CSS 작성 시 가독성 향상 (빈 '' 제거 가능, 더 명확한 CSS)
-` tailwind-merge` `clsx` 라이브러리 설치 ( 각각 0.3kb, 1kb 경량 라이브러리 )


**2. tailwindCSS 설정**
- 픽셀 단위 작업 시 생산성 향상
- 기존 코드 text-[12px] ---> text-12 
- 기존 코드에 영향을 주지 않음
- rem단위가 포함된 공통 컴포넌트 존재 ->  px단위로 교체하거나 rem붙여줘야함


## 🖼️ 스크린샷

`기존 코드`
<img width="476" alt="image" src="https://github.com/user-attachments/assets/fe0575ab-6cb5-4e96-badd-203f859816ce" />

`cn함수 도입 후`
<img width="465" alt="image" src="https://github.com/user-attachments/assets/8b2525a8-9654-44f8-9ab6-4119871c2b6f" />



--- 

## 🙏 리뷰 요구사항

생산성 및 가독성 향상을 위해 건의 드립니다 !
실제 사용해봤을때 그 장점이 체감되었던 경험이 있어서 제안드립니다.



