### PR TITLE
refactor: 전역 에러 처리 시스템 구축 및 중복 alert 방지

### DIFF
--- a/src/app/api/axiosInstance.ts
+++ b/src/app/api/axiosInstance.ts
@@ -31,8 +31,9 @@ axiosInstance.interceptors.request.use(
 axiosInstance.interceptors.response.use(
   (response: AxiosResponse) => response.data,
   async (error: AxiosError) => {
+    const originalRequest = error.config as any
+
     if (!error.response) {
-      alert('네트워크 오류가 발생했습니다. 다시 시도해 주세요.')
       throw new ErrorResponse(0, 0, 'Network Error')
     }
 
@@ -42,24 +43,24 @@ axiosInstance.interceptors.response.use(
 
     const errorResponse = new ErrorResponse(status, code, message)
 
-    if (status === 401) {
+    if (status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true
+
       const { accessToken, setAccessToken } = useAuthStore.getState()
 
       if (accessToken) {
-        const { accessToken: newAccessToken } = await postRefreshToken()
         try {
+          const { accessToken: newAccessToken } = await postRefreshToken()
           setAccessToken(newAccessToken)
-        } catch (error) {
-          if (error instanceof Error) {
-            window.location.href = '/auth/signin'
-            console.error(error)
-          }
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`
+
+          return axiosInstance(originalRequest)
+        } catch (refreshError) {
+          window.location.href = '/auth/signin'
+          console.error(refreshError)
+          throw errorResponse
         }
       }
-    }
-    if (status === 500) {
-      alert('서버에서 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.')
-      throw errorResponse
     }
 
     throw errorResponse

--- a/src/lib/QueryProvider.tsx
+++ b/src/lib/QueryProvider.tsx
@@ -51,8 +51,6 @@ function handleQueryError(error: unknown) {
 let lock = false
 
 function alertOnce(msg: string) {
-  const now = Date.now()
-
   if (lock) return
 
   lock = true

--- a/src/lib/QueryProvider.tsx
+++ b/src/lib/QueryProvider.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { useState } from 'react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { StrictPropsWithChildren } from '@/types/react'
+import { ErrorResponse } from '@/app/api/api.types'
 
 export default function QueryProvider({ children }: StrictPropsWithChildren) {
   const [queryClient] = useState(
@@ -13,11 +14,50 @@ export default function QueryProvider({ children }: StrictPropsWithChildren) {
             refetchOnMount: false,
             refetchOnWindowFocus: false,
             staleTime: 60 * 1000,
-            retry: 1,
           },
         },
+        queryCache: new QueryCache({
+          onError: (error) => {
+            handleQueryError(error)
+          },
+        }),
       })
   )
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+function handleQueryError(error: unknown) {
+  if (error instanceof ErrorResponse) {
+    if (error.status === 0) {
+      alertOnce(`Network Error: ${error.message}`)
+      return
+    }
+    if (error.status === 500) {
+      alertOnce(`Server Error: ${error.message}`)
+      return
+    }
+    if (error.status >= 400 && error.status < 500) {
+      alertOnce(error.message)
+      return
+    }
+  } else if (error instanceof Error) {
+    alertOnce(error.message)
+  } else {
+    alertOnce('오류가 발생했습니다.')
+  }
+}
+
+let lock = false
+
+function alertOnce(msg: string) {
+  const now = Date.now()
+
+  if (lock) return
+
+  lock = true
+  alert(msg)
+  setTimeout(() => {
+    lock = false
+  }, 1000)
 }


### PR DESCRIPTION
## 🔗 이슈

1.	여러 API에서 에러가 동시에 발생할 경우, 각 에러마다 alert가 중복 표시되어 UX가 저하되는 문제
2.	액세스 토큰 만료 시 refresh 요청 후 기존 요청을 재시도하는 로직이 누락되어, 웹이 멈춰보이는 문제

## 🎲 PR 유형

어떤 **변경 사항**이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 기능 삭제
- [ ] 디자인 추가 및 수정
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기능에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경, 주석 추가 및 수정)


--- 

## 🪄 작업 내용


**refresh 요청 후 기존 요청 재시도**
- 액세스 토큰 만료(401) 시 refresh 토큰을 사용하여 새로운 액세스 토큰을 발급받고, 실패했던 기존 요청을 재시도하는 로직 추가

**QueryProvider 전역 에러 처리**
- axios 인스턴스는 인증 관련 처리만 담당하고, 에러를 ErrorResponse 래핑하여 throw
- QueryProvider의 전역 onError 콜백을 사용하여 에러 알림 처리
- lock을 사용해 1초 이내의 다중 에러는 최초의 에러만 alert 표시

기존 axios인스턴스에서 에러핸들링을 확장할 수도 있었지만, 
에러 알림은 화면/맥락에 따라 개별 쿼리에서 다르게 처리하거나 아예 불필요할 수 있어 확장성과 일관성을 위해 axios 인스턴스에서  QueryProvider으로 핸들링 로직을 옮겼습니다 !




--- 

## 🙏 리뷰 요구사항
x


## ✅ 체크리스트(PR 올리기 전 아래 내용을 확인해주세요.)

- [x] Reviewers를 지정해주세요.
- [x] Assignees는 본인을 선택해주세요.
- [x] label을 선택해주세요.
